### PR TITLE
optionally append access token into userinfo

### DIFF
--- a/ckanext/oidc_pkce/views.py
+++ b/ckanext/oidc_pkce/views.py
@@ -133,7 +133,9 @@ def callback():
         config.userinfo_url(),
         headers={"Authorization": f"Bearer {access_token}"},
     ).json()
-
+    if access_token:
+        userinfo["access_token"] = access_token
+    
     user = utils.sync_user(userinfo)
     if not user:
         error = "Unique user not found"

--- a/ckanext/oidc_pkce/views.py
+++ b/ckanext/oidc_pkce/views.py
@@ -141,7 +141,7 @@ def callback():
     ).json()
 
     userinfo["access_token"] = access_token
-    
+
     user = utils.sync_user(userinfo)
     if not user:
         error = "Unique user not found"

--- a/ckanext/oidc_pkce/views.py
+++ b/ckanext/oidc_pkce/views.py
@@ -131,6 +131,7 @@ def callback():
     if not access_token:
         error = "No access token returned from the token endpoint."
         log.error("Error: %s", error)
+        tk.h.flash_error(error)
         session[SESSION_ERROR] = error
         return tk.redirect_to(came_from)
 

--- a/ckanext/oidc_pkce/views.py
+++ b/ckanext/oidc_pkce/views.py
@@ -128,13 +128,19 @@ def callback():
 
     access_token = exchange["access_token"]
 
+    if not access_token:
+        error = "No access token returned from the token endpoint."
+        log.error("Error: %s", error)
+        session[SESSION_ERROR] = error
+        return tk.redirect_to(came_from)
+
     # Authorization flow successful, get userinfo and login user
     userinfo = requests.get(
         config.userinfo_url(),
         headers={"Authorization": f"Bearer {access_token}"},
     ).json()
-    if access_token:
-        userinfo["access_token"] = access_token
+
+    userinfo["access_token"] = access_token
     
     user = utils.sync_user(userinfo)
     if not user:


### PR DESCRIPTION
In this pull request, we append the `access_token` into `userinfo`, if it exists. 


This change is inspired from a CKAN extension that my team is working on, where we integrate Auth0 for our target CKAN platform.