### PR TITLE
Don't override fullname if already populated

### DIFF
--- a/ckanext/oidc_pkce/interfaces.py
+++ b/ckanext/oidc_pkce/interfaces.py
@@ -59,6 +59,8 @@ class IOidcPkce(Interface):
 
             user_dict.update(data)
             user_dict.pop("name")  # Username is untouched, so exclude it from the update payload.
+            if user_dict.get("fullname", None):
+                data.pop("fullname")  # Don't override fullname if it is already populated
             tk.get_action("user_update")({"user": admin["name"]}, user_dict)
 
             signals.user_sync.send(user.id)


### PR DESCRIPTION
If the account has already set its visible name before using SSO, don't override it.